### PR TITLE
增加日志堆栈，可选日志级别

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	utils.WriteLogToFS()
+	utils.WriteLogToFS(utils.LogInfoLevel, utils.LogWithStack)
 	config.Init()
 }
 

--- a/app.go
+++ b/app.go
@@ -35,7 +35,7 @@ func main() {
 	bot.RefreshList()
 
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, os.Kill)
+	signal.Notify(ch, os.Interrupt)
 	<-ch
 	bot.Stop()
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"path"
 	"time"
 
@@ -9,25 +10,44 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type LogArg uint32
+
+const (
+	LogFatalLevel        = LogArg(logrus.FatalLevel)
+	LogErrorLevel        = LogArg(logrus.ErrorLevel)
+	LogWarnLevel         = LogArg(logrus.WarnLevel)
+	LogInfoLevel         = LogArg(logrus.InfoLevel)
+	LogDebugLevel        = LogArg(logrus.DebugLevel)
+	LogTraceLevel        = LogArg(logrus.TraceLevel)
+	logLevelMask  LogArg = 0x07
+	LogWithStack  LogArg = 0x08
+)
+
+var logWithStack = false
+
 // GetModuleLogger - 提供一个为 Module 使用的 logrus.Entry
 // 包含 logrus.Fields
-func GetModuleLogger(name string) *logrus.Entry {
-	return logrus.WithField("module", name)
+func GetModuleLogger(name string) logrus.FieldLogger {
+	if logWithStack {
+		return &errorEntryWithStack{logrus.WithField("module", name)}
+	} else {
+		return logrus.WithField("module", name)
+	}
 }
 
 // WriteLogToFS 将日志转储至文件
 // 请务必在 init() 阶段调用此函数
 // 否则会出现日志缺失
 // 日志存储位置 ./logs
-func WriteLogToFS() {
-	WriteLogToPath("logs")
+func WriteLogToFS(args ...LogArg) {
+	WriteLogToPath("logs", args...)
 }
 
 // WriteLogToPath 将日志转储至文件
 // 请务必在 init() 阶段调用此函数
 // 否则会出现日志缺失
 // 日志存储位置 p
-func WriteLogToPath(p string) {
+func WriteLogToPath(p string, args ...LogArg) {
 	writer, err := rotatelogs.New(
 		path.Join(p, "%Y-%m-%d.log"),
 		rotatelogs.WithMaxAge(7*24*time.Hour),
@@ -37,11 +57,50 @@ func WriteLogToPath(p string) {
 		logrus.WithError(err).Error("unable to write logs")
 		return
 	}
-	logrus.AddHook(lfshook.NewHook(
-		lfshook.WriterMap{
-			logrus.InfoLevel:  writer,
-			logrus.ErrorLevel: writer,
-			logrus.FatalLevel: writer,
-		}, &logrus.JSONFormatter{},
-	))
+
+	var arg LogArg
+	for _, a := range args {
+		arg |= a
+	}
+	if arg&LogWithStack == LogWithStack {
+		logWithStack = true
+	}
+	logLevel := arg & logLevelMask
+	if logLevel == 0 {
+		logLevel = LogInfoLevel
+	}
+
+	writerMap := make(lfshook.WriterMap)
+	switch {
+	case logLevel > LogFatalLevel:
+		writerMap[logrus.FatalLevel] = writer
+		fallthrough
+	case logLevel > LogErrorLevel:
+		writerMap[logrus.ErrorLevel] = writer
+		fallthrough
+	case logLevel > LogWarnLevel:
+		writerMap[logrus.WarnLevel] = writer
+		fallthrough
+	case logLevel > LogInfoLevel:
+		writerMap[logrus.InfoLevel] = writer
+		fallthrough
+	case logLevel > LogDebugLevel:
+		writerMap[logrus.DebugLevel] = writer
+		fallthrough
+	case logLevel > LogTraceLevel:
+		writerMap[logrus.TraceLevel] = writer
+	}
+	if logWithStack {
+		logrus.AddHook(lfshook.NewHook(writerMap, &logrus.TextFormatter{DisableQuote: true}))
+	} else {
+		logrus.AddHook(lfshook.NewHook(writerMap, &logrus.JSONFormatter{}))
+	}
+}
+
+type errorEntryWithStack struct {
+	*logrus.Entry
+}
+
+func (e *errorEntryWithStack) WithError(err error) *logrus.Entry {
+	return e.Entry.WithError(fmt.Errorf("%+v", err))
 }


### PR DESCRIPTION
因为`utils/log.go`关于日志的部分基本都是写死在代码里的，因此当使用go mod引入时，会导致很不好用。
主要修改了`WriteLogToFS()`和`WriteLogToPath()`。为了兼容原先的代码，允许传入一个可变参数。更新内容如下：
1. 可以配置日志级别，从`Fatal`到 `Trace` ，默认为`Info`。
2. 如果代码中使用了 [github.com/pkg/errors](https://github.com/pkg/errors) ，`error`里将会含有堆栈信息，而默认的logrus不会打印堆栈信息，需要使用`+v`才能够打印出来。
```go
fmt.Errorf("%+v", err)
```
3. 更新了`app.go`，展示了参数传入方法。（兼容已有的代码，也可以不传参数，和之前的效果没有区别）
```go
utils.WriteLogToFS(utils.LogInfoLevel, utils.LogWithStack)
```
4. 修复了一个小BUG，`os.Kill`是不能被监听的。

为了兼容已有的代码，这里写的比较丑。强烈建议在v2中加入这些配置。