### PR TITLE
抽象初始化和登录逻辑，提供编译为android so的选项

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -1,3 +1,4 @@
 bot:
-  account: 123455667
-  password: 3456346sdfgsd
+  loginmethod: qrcode
+  account: ""
+  password: ""

--- a/cmd/lib/build_android_bind.sh
+++ b/cmd/lib/build_android_bind.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+export ANDROID_HOME="please specify manually"
+export ANDROID_NDK_HOME="please specify manually"
+gomobile bind -target=andorid/arm64 -o miraigo-template.aar

--- a/cmd/lib/lib.go
+++ b/cmd/lib/lib.go
@@ -1,0 +1,21 @@
+package lib
+
+import (
+	"fmt"
+	"github.com/Logiase/MiraiGo-Template/bot"
+	"github.com/Logiase/MiraiGo-Template/config"
+	_ "golang.org/x/mobile/bind"
+)
+
+func init() {
+	fmt.Println("bot as lib")
+}
+
+func InitBot(configJSONContent string, deviceJSONContent string) {
+	config.InitWithContent([]byte(configJSONContent))
+	bot.InitWithDeviceJSONContent([]byte(deviceJSONContent))
+	bot.StartService()
+	bot.UseProtocol(bot.IPad)
+	bot.Login()
+	bot.RefreshList()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -25,5 +26,13 @@ func Init() {
 	err := GlobalConfig.ReadInConfig()
 	if err != nil {
 		logrus.WithField("config", "GlobalConfig").WithError(err).Panicf("unable to read global config")
+	}
+}
+
+func InitWithContent(configJSONContent []byte) {
+	GlobalConfig.SetConfigType("json")
+	err := GlobalConfig.ReadConfig(bytes.NewReader(configJSONContent))
+	if err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
看到很多直接的文件读写操作，不够灵活，抽象为传入[]byte的接口，这样就可以同时支持内存初始化和文件初始化

为什么要加编译为android so的选项呢？为了方便直接嵌入qq运行（国内ROM基本是把qq当守护进程养着），完成一些不单独购买服务器场景下的消息转发之类的需求，又不用hook qq客户端本身的逻辑
如果觉得不需要这个选项，可以不包括cmd/lib/lib.go和build_android_bind.sh，去掉之后对项目没有影响
